### PR TITLE
added #before_mass_update and #after_mass_update callback on objectab…

### DIFF
--- a/lib/objectmancy/objectable.rb
+++ b/lib/objectmancy/objectable.rb
@@ -35,7 +35,9 @@ module Objectmancy
     # @param attrs [Hash] Attributes to update
     def mass_update(attrs = {})
       tap do
+        before_mass_update
         _attributes_update!(attrs)
+        after_mass_update
       end
     end
 
@@ -58,6 +60,12 @@ module Objectmancy
 
     # Empty after_initialize callback
     def after_initialize; end
+
+    # Empty before mass_update callback
+    def before_mass_update; end
+
+    # Empty after mass_update callback
+    def after_mass_update; end
 
     # Determines which attributes are assignable
     #

--- a/test/objectmancy/objectable/mass_update_test.rb
+++ b/test/objectmancy/objectable/mass_update_test.rb
@@ -31,4 +31,16 @@ class ObjectableMassUpdateTest < Minitest::Test
     test_obj = ObjTestClasses::TestObject.new(name: 'old name')
     assert_same(test_obj, test_obj.mass_update(name: 'new', primes: [1, 2]))
   end
+
+  def test_before_callback
+    test_obj = ObjTestClasses::TestObject.new
+    test_obj.mass_update(name: 'before')
+    assert_equal(:before_update_set, test_obj.before_mass_update_set)
+  end
+
+  def test_after_callback
+    test_obj = ObjTestClasses::TestObject.new
+    test_obj.mass_update(name: 'after')
+    assert_equal(:after_update_set, test_obj.after_mass_update_set)
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,7 +49,10 @@ module ObjTestClasses
   class TestObject
     include Objectmancy::Objectable
 
-    attr_reader :before_init, :after_init
+    attr_reader :before_init,
+                :after_init,
+                :before_mass_update_set,
+                :after_mass_update_set
 
     attribute :name
 
@@ -70,6 +73,14 @@ module ObjTestClasses
 
     def after_initialize
       @after_init = :after_set
+    end
+
+    def before_mass_update
+      @before_mass_update_set = :before_update_set
+    end
+
+    def after_mass_update
+      @after_mass_update_set = :after_update_set
     end
   end
 end


### PR DESCRIPTION
…le#mass_update, expanded TestObject in test_helper.rb adding #before_mass_update and #after_mass_update methods, added tests in mass_update_test.

Resolves issue [#3](https://github.com/jon2992/objectmancy/issues/3), I'm not sure if you want mass_update callbacks to edit the callback variables set by the initialize method or setting new variables from mass_update.  It probably just matters how the user/client application sets up their own class and implements those methods.  In the test I expanded your test helper with variables for before and after mass_update.  If you need me to switch something up let me know, I'm happy to help. 